### PR TITLE
Fix geocode api rate limit

### DIFF
--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -33,6 +33,7 @@ services:
       ROCKET_ADDRESS: 0.0.0.0
     secrets:
       - POSTGRES_PASSWORD
+      - GEOCODE_API_KEY
     volumes:
       - .watchdir:/home/.watchdir
 
@@ -65,3 +66,5 @@ volumes:
 secrets:
   POSTGRES_PASSWORD:
     file: ./secrets/POSTGRES_PASSWORD
+  GEOCODE_API_KEY:
+    file: ./secrets/GEOCODE_API_KEY

--- a/backend/secrets/GEOCODE_API_KEY
+++ b/backend/secrets/GEOCODE_API_KEY
@@ -1,0 +1,1 @@
+changeme


### PR DESCRIPTION
There was an update to the geocoding api we were using to locate the longitude/latitude parsed by the filewatcher. They are now rate limiting to 1 free api call every second, and they also now force each user to use an API key.